### PR TITLE
fix: Reduce Hallucinated links in ARMD Ebooks Plugin

### DIFF
--- a/.github/workflows/pipeline.deployment.yml
+++ b/.github/workflows/pipeline.deployment.yml
@@ -22,10 +22,10 @@ on:
         type: boolean
 
 jobs:
-    # contract-test:
-    #   secrets: inherit
-    #   uses: ./.github/workflows/job.contract-test.yml
+    contract-test:
+      secrets: inherit
+      uses: ./.github/workflows/job.contract-test.yml
     deploy:
-      # needs: contract-test
+      needs: contract-test
       secrets: inherit
       uses: ./.github/workflows/job.deploy-cloudrun.yml

--- a/plugins/armdEbooks/index.js
+++ b/plugins/armdEbooks/index.js
@@ -1,10 +1,8 @@
-
 import Turndown from 'turndown'
 import { BasePlugin } from 'madi-plg-base-class'
 var turndownService = new Turndown()
 
 const TOOLNAME = 'search_armd_ebooks'; // Identifier for the plugin
-
 export const test = true;
 
 // The static description object for the Confluence search tool.
@@ -54,7 +52,6 @@ export class Plugin extends BasePlugin {
    */
   async run(runOptions, params) {
     // Destructure the search parameters or set defaults
-
     const related = (await this.chunks?.find({
       ...params,
       query: {
@@ -64,7 +61,6 @@ export class Plugin extends BasePlugin {
         $limit: 50
       }
     }))?.data ?? [];
-
 
     const filled = await Promise.all(
       related.map(async (c) => {
@@ -92,8 +88,7 @@ export class Plugin extends BasePlugin {
     });
 
 
-    const INSTRUCTION = `INSTRUCTIONS: Below are several snippets from ebooks published by NASA ARMD pertaining to your request. They are in order of closeness depending on the cosine similarity of the embeddings of the query and the snippet.  They also include abstracts and metadata of the full documents.  When responding make sure to include the relevant links to the documents and name the document from which the snippet was pulled.`
-
+    const INSTRUCTION = `INSTRUCTIONS: Below are several snippets from ebooks published by NASA ARMD pertaining to your request. They are in order of closeness depending on the cosine similarity of the embeddings of the query and the snippet.  They also include abstracts and metadata of the full documents.  Respond only with information provided by ther snippets. When responding make sure to include the relevant links to the documents and name the document from which the snippet was pulled.  Do not guess at links, names, or other data points. It is CRITICAL that you only use the exact links returned in the document metadata or redirect to the user to www.nasa.gov/ebooks/#aeronautics, otherwise return no link at at. If you are unable to find the information requested, please respond with "No information found".\n\n`
     const snippets = '##Snippet\n' + cleaned?.map(d => JSON.stringify(d)).join('\n\n##Snippet\n');
     return {"content":INSTRUCTION + snippets}
   }


### PR DESCRIPTION
### Summary

**Type:** ci

* **What kind of change does this PR introduce?**
  * This PR re-enables the previously commented out `contract-test` job in the CI pipeline and updates the instructional text within the `Plugin` class in the `armdEbooks` plugin.

* **What is the current behavior?**
  * The `contract-test` job was commented out, preventing its execution during CI runs. The instructional text in the `Plugin` class was less specific about how to handle document links and data.

* **What is the new behavior?**
  * The `contract-test` job is now active, ensuring it runs as part of the CI process. The instructional text within the `Plugin` class has been updated to be more specific about using exact links and not guessing data points, enhancing the accuracy and reliability of the plugin output.

* **Does this PR introduce a breaking change?**
  * No breaking changes are introduced. Existing functionality is preserved, with improvements to documentation and CI processes.

* **Has Testing been included for this PR?
  * No new tests have been added; existing tests should validate the changes as the modifications are primarily operational and textual.

### Other Information

This update ensures that our CI pipeline is more robust by including all necessary tests, and improves user guidance within the `armdEbooks` plugin to prevent potential misuse of the data retrieval process.